### PR TITLE
Make sure only the SKU span element is selected

### DIFF
--- a/sites/bestbuy.py
+++ b/sites/bestbuy.py
@@ -78,7 +78,7 @@ class BestBuy:
                 if r.status_code == 200:
                     doc = lxml.html.fromstring(r.text)
                     if not image_found:
-                        self.sku_id = doc.xpath('//span[@class="product-data-value body-copy"]/text()')[1].strip()
+                        self.sku_id = doc.xpath('//div[@class="sku product-data"]/span[@class="product-data-value body-copy"]/text()')[0].strip()
                         product_image = doc.xpath('//img[@class="primary-image"]/@src')[0]
                         self.image_signal.emit(product_image)
                         image_found = True


### PR DESCRIPTION
Currently the code expects 2 span elements with class `product-data-value body-copy` and selects the 2nd element.  This is not the case when the product model is missing (see https://www.bestbuy.com/site/msi-geforce-rtx-3080-ventus-3x-10g-oc-bv-gddr6x-pci-express-4-0-graphic-card-black-silver/6430175.p?skuId=6430175).